### PR TITLE
fix: security 설정 변경

### DIFF
--- a/core/src/main/java/com/lastone/core/security/jwt/JwtProvider.java
+++ b/core/src/main/java/com/lastone/core/security/jwt/JwtProvider.java
@@ -12,8 +12,8 @@ import java.util.*;
 
 public class JwtProvider {
 
-    private static final int ACCESS_TOKEN_TIME = 10 * 60 * 1000;
-    private static final int REFRESH_TOKEN_TIME = 30 * 60 * 1000;
+    private static final int ACCESS_TOKEN_TIME = 3 * 60 * 60 * 1000;
+    private static final int REFRESH_TOKEN_TIME = 24 * 60 * 60 * 1000;
     private static final String secretKey = "test";
     private static final Algorithm algorithm = Algorithm.HMAC256(secretKey.getBytes());
 

--- a/core/src/main/java/com/lastone/core/security/oauth2/KakaoOauth2UserInfo.java
+++ b/core/src/main/java/com/lastone/core/security/oauth2/KakaoOauth2UserInfo.java
@@ -3,6 +3,7 @@ package com.lastone.core.security.oauth2;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Map;
 
@@ -10,19 +11,29 @@ import java.util.Map;
 @ToString
 public class KakaoOauth2UserInfo {
 
-    protected Map<String, Object> attributes;
+    protected final Map<String, Object> attributes;
+
+    private final Map<String, Object> kakaoAccount;
 
     public KakaoOauth2UserInfo(Map<String, Object> attributes) {
         this.attributes = attributes;
+        this.kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
     }
 
     public String getEmail() {
-        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
         return (String) kakaoAccount.get("email");
     }
 
     public String getNickname() {
-        return "닉네임";
+        Map<String, String> profile = (Map<String, String>) kakaoAccount.get("profile");
+        return profile.get("nickname");
+    }
 
+    public String getGender() {
+        String gender = (String) kakaoAccount.get("gender");
+        if (gender.equals("male")) {
+            return "남";
+        }
+        return "여";
     }
 }

--- a/core/src/main/java/com/lastone/core/security/oauth2/Oauth2UserService.java
+++ b/core/src/main/java/com/lastone/core/security/oauth2/Oauth2UserService.java
@@ -1,8 +1,7 @@
 package com.lastone.core.security.oauth2;
 
-import antlr.StringUtils;
 import com.lastone.core.domain.member.Member;
-import com.lastone.core.domain.member.MemberRepository;
+import com.lastone.core.repository.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
@@ -34,6 +33,7 @@ public class Oauth2UserService extends DefaultOAuth2UserService {
 
         String email = kakaoOauth2UserInfo.getEmail();
         String nickname = kakaoOauth2UserInfo.getNickname();
+        String gender = kakaoOauth2UserInfo.getGender();
 
         if (email == null) {
             throw new IllegalArgumentException("카카오 email은 필수 입력 값입니다.");
@@ -44,6 +44,7 @@ public class Oauth2UserService extends DefaultOAuth2UserService {
             Member member = Member.builder()
                     .email(email)
                     .nickname(nickname)
+                    .gender(gender)
                     .build();
             memberRepository.save(member);
         }


### PR DESCRIPTION
- 토큰 유효시간 변경
- AuthorizationFilter UserDetails Optional로 반환
- 카카오 이메일 뿐만 아니라 성별과 닉네임 까지 받는 방식으로 수정