### PR TITLE
Feature/errorcode create

### DIFF
--- a/core/src/main/java/com/lastone/core/dto/BaseResponse.java
+++ b/core/src/main/java/com/lastone/core/dto/BaseResponse.java
@@ -1,0 +1,13 @@
+package com.lastone.core.dto;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BaseResponse {
+    int statusCode;
+
+    public BaseResponse(int statusCode) {
+        this.statusCode = statusCode;
+    }
+}

--- a/core/src/main/java/com/lastone/core/dto/FailureResponse.java
+++ b/core/src/main/java/com/lastone/core/dto/FailureResponse.java
@@ -1,0 +1,46 @@
+package com.lastone.core.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.boot.context.properties.bind.validation.ValidationErrors;
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class FailureResponse extends BaseResponse {
+
+    private String errorCode;
+    private String message;
+    @JsonInclude
+    private List<ValidationError> errors;
+
+    public FailureResponse(int statusCode, String errorCode, String message) {
+        super(statusCode);
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+    public FailureResponse(List<ValidationError> errors, int statusCode, String errorCode, String message) {
+        super(statusCode);
+        this.errorCode = errorCode;
+        this.message = message;
+        this.errors = errors;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class ValidationError {
+
+        private final String field;
+        private final String message;
+
+        public static ValidationError of(final FieldError fieldError) {
+            return new ValidationError(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+    }
+}

--- a/core/src/main/java/com/lastone/core/exception/ErrorCode.java
+++ b/core/src/main/java/com/lastone/core/exception/ErrorCode.java
@@ -1,0 +1,37 @@
+package com.lastone.core.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+
+  SYSTEM_EXCEPTION(500, "S000", "Internal Server Error"),
+  NOT_FOUND_HANDLER(404, "S404", "404 NOT FOUND"),
+
+  INVALID_INPUT_VALUE(400, "L001", "Invalid Input Value"),
+  METHOD_NOT_ALLOWED(405, "L002", "Method not allowed"),
+  INTERNAL_SERVER_ERROR(500, "C004", "Server Error"),
+  INVALID_TYPE_VALUE(400, "C005", "Invalid Type Value"),
+
+  HANDLE_ACCESS_DENIED(403, "B006", "Access is Denied"),
+  UNAUTHORIZED(401, "U002", "Not Authorized on user"),
+
+  NOT_FOUND_USER(404, "U001", "No such User"),
+  NOT_FOUND_POST(404, "P001", "No such Post"),
+
+  JWT_DECODE_FAILURE(500, "J001", "JWT cannot be decoded"),
+  JWT_ENCODE_FAILURE(500, "J002", "DTO encode failure"),
+
+  FILE_FETCH_FAILURE(500, "S001", "File fetch failure (from storage)"),
+
+  ;
+  private final String code;
+  private final String message;
+  private int status;
+
+  ErrorCode(final int status, final String code, final String message) {
+    this.status = status;
+    this.message = message;
+    this.code = code;
+  }
+}


### PR DESCRIPTION
### 한 것

- 에러코드를 enum 클래스인 ErrorCode로 만들어 규격화 시킴.
- RuntimeException을 상속받는 클래스를 만들어 추후에 ExceptionHandler에서 사용할 수 있게 함.
- ErrorCode를 사용해 Response할 수 있게 FailureResponse 객체를 생성 함.