### PR TITLE
채팅방 생성

### DIFF
--- a/chatting-server/src/main/java/com/lastone/chat/controller/ChatRoomController.java
+++ b/chatting-server/src/main/java/com/lastone/chat/controller/ChatRoomController.java
@@ -1,17 +1,30 @@
 package com.lastone.chat.controller;
 
+import com.lastone.chat.service.ChatRoomService;
+import com.lastone.core.dto.chatroom.ChatRoomCreateReqDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
 @RequestMapping("/chat-room")
+@RequiredArgsConstructor
 public class ChatRoomController {
+    private final ChatRoomService chatRoomService;
     @GetMapping("/{roomId}")
     public String getRoom(@PathVariable Long roomId, Model model) {
         model.addAttribute("roomId", roomId);
         return "chat/chat";
+    }
+    @PostMapping
+    public ResponseEntity<Long> createChatRoom(@RequestBody ChatRoomCreateReqDto chatRoomCreateReqDto) {
+        Long userId = 5L;
+        return ResponseEntity.ok(chatRoomService.createRoom(userId, chatRoomCreateReqDto));
     }
 }

--- a/chatting-server/src/main/java/com/lastone/chat/exception/ChatException.java
+++ b/chatting-server/src/main/java/com/lastone/chat/exception/ChatException.java
@@ -1,0 +1,14 @@
+package com.lastone.chat.exception;
+
+import com.lastone.core.exception.ErrorCode;
+import com.lastone.core.exception.LastOneException;
+
+public class ChatException extends LastOneException {
+    public ChatException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+
+    public ChatException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/chatting-server/src/main/java/com/lastone/chat/service/ChatRoomService.java
+++ b/chatting-server/src/main/java/com/lastone/chat/service/ChatRoomService.java
@@ -1,0 +1,7 @@
+package com.lastone.chat.service;
+
+import com.lastone.core.dto.chatroom.ChatRoomCreateReqDto;
+
+public interface ChatRoomService {
+    Long createRoom(Long userId, ChatRoomCreateReqDto createReqDto);
+}

--- a/chatting-server/src/main/java/com/lastone/chat/service/ChatRoomServiceImpl.java
+++ b/chatting-server/src/main/java/com/lastone/chat/service/ChatRoomServiceImpl.java
@@ -1,0 +1,71 @@
+package com.lastone.chat.service;
+
+import com.lastone.chat.exception.ChatException;
+import com.lastone.core.repository.ChatRoomRepository;
+import com.lastone.core.domain.chat.ChatRoom;
+import com.lastone.core.domain.chat.ChatStatus;
+import com.lastone.core.dto.chatroom.ChatRoomCreateReqDto;
+import com.lastone.core.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomServiceImpl implements ChatRoomService {
+    private final ChatRoomRepository chatRoomRepository;
+
+    /**
+     * 채팅방을 생성하기 전, 이미 해당 참여자가 있는지 확인
+     * 없다면 채팅방 생성
+     * 있다면 해당 채팅방의 번호 반환
+     */
+    @Override
+    public Long createRoom(Long userId, ChatRoomCreateReqDto createReqDto) {
+        Map<String, Long> userIdMap = userIdSort(userId, createReqDto.getParticipationId());
+        Long hostId = userIdMap.get("hostId");
+        Long participationId = userIdMap.get("participationId");
+
+        Optional<ChatRoom> chatRoomOptional = chatRoomRepository.findByHostIdAndParticipationId(hostId, participationId);
+
+        if(!chatRoomOptional.isPresent()) {
+            ChatRoom createChatRoom = ChatRoom.create(hostId, participationId);
+            ChatRoom save = chatRoomRepository.save(createChatRoom);
+            return save.getId();
+        }else {
+            isRoomValidation(chatRoomOptional.get().getStatus());
+        }
+        return chatRoomOptional.get().getId();
+    }
+    private void isRoomValidation(ChatStatus roomStatus) {
+        if(roomStatus.equals(ChatStatus.BLOCKED)) {
+            throw new ChatException(ErrorCode.BLOCKED_CHAT_ROOM);
+        }
+        if(roomStatus.equals(ChatStatus.DELETED)) {
+            throw new ChatException(ErrorCode.ALREADY_DELETED_CHAT_ROOM);
+        }
+    }
+    private Map<String, Long> userIdSort(Long loginedMemberId, Long otherMemberId) {
+        Map<String, Long> userMap = new HashMap<>();
+        Long hostId;
+        Long participationId;
+
+        if(isBiggerThanOtherUserId(loginedMemberId, otherMemberId)) {
+            hostId = loginedMemberId;
+            participationId = otherMemberId;
+        }else {
+            hostId = otherMemberId;
+            participationId = loginedMemberId;
+        }
+        userMap.put("hostId", hostId);
+        userMap.put("participationId", participationId);
+
+        return userMap;
+    }
+    private boolean isBiggerThanOtherUserId(Long loginedMemberId, Long otherMemberId) {
+        return loginedMemberId > otherMemberId;
+    }
+}

--- a/core/src/main/java/com/lastone/core/domain/chat/ChatRoom.java
+++ b/core/src/main/java/com/lastone/core/domain/chat/ChatRoom.java
@@ -1,6 +1,5 @@
 package com.lastone.core.domain.chat;
 
-import com.lastone.core.dto.chatroom.ChatRoomCreateReqDto;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -52,9 +51,11 @@ public class ChatRoom {
         this.updatedAt = LocalDateTime.now();
     }
 
-    public ChatRoom(ChatRoomCreateReqDto createReqDto) {
-        this.hostId = createReqDto.getHostId();
-        this.participationId = createReqDto.getParticipationId();
-        this.status = ChatStatus.NORMAL;
+    public static ChatRoom create(Long hostId, Long participationId) {
+        ChatRoom chatRoom = new ChatRoom();
+        chatRoom.hostId = hostId;
+        chatRoom.participationId = participationId;
+        chatRoom.status = ChatStatus.NORMAL;
+        return chatRoom;
     }
 }

--- a/core/src/main/java/com/lastone/core/dto/chatroom/ChatRoomCreateReqDto.java
+++ b/core/src/main/java/com/lastone/core/dto/chatroom/ChatRoomCreateReqDto.java
@@ -1,10 +1,14 @@
 package com.lastone.core.dto.chatroom;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class ChatRoomCreateReqDto {
     private Long hostId;
     private Long participationId;

--- a/core/src/main/java/com/lastone/core/exception/ErrorCode.java
+++ b/core/src/main/java/com/lastone/core/exception/ErrorCode.java
@@ -23,7 +23,9 @@ public enum ErrorCode {
   JWT_ENCODE_FAILURE(500, "J002", "DTO encode failure"),
 
   FILE_FETCH_FAILURE(500, "S001", "File fetch failure (from storage)"),
-
+  /* Chatting */
+  ALREADY_DELETED_CHAT_ROOM(404, "CR001", "지워진 채팅방입니다."),
+  BLOCKED_CHAT_ROOM(404, "CR002", "차단된 채팅방입니다.")
   ;
   private final String code;
   private final String message;

--- a/core/src/main/java/com/lastone/core/exception/LastOneException.java
+++ b/core/src/main/java/com/lastone/core/exception/LastOneException.java
@@ -1,0 +1,20 @@
+package com.lastone.core.exception;
+
+public class LastOneException extends RuntimeException {
+    private ErrorCode errorCode;
+
+    public LastOneException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public LastOneException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+}

--- a/core/src/main/java/com/lastone/core/repository/ChatRoomRepository.java
+++ b/core/src/main/java/com/lastone/core/repository/ChatRoomRepository.java
@@ -1,0 +1,10 @@
+package com.lastone.core.repository;
+
+import com.lastone.core.domain.chat.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+    Optional<ChatRoom> findByHostIdAndParticipationId(Long hostId, Long participationId);
+}


### PR DESCRIPTION
### 한 것
채팅방 Entity 수정
  - 내부에서 static 메서드를 통해 객체생성해서 반환하는 형식으로 수정
- Chatting 모듈에서 사용할 LastOneException을 상속받는 ChatException 생성

공통적으로 사용할 RuntimeException을 상속받는 LastOneException 생성
채팅방 생성
- Service 단에서 회원들의 번호를 받아 없다면 생성,
  - 채팅방을 구성할 때 어떻게 구성하는게 나을지 생각을 해봤는데, hostId와 participationId가 정렬되어있다면 조회시 2번 검색하지 않아 검색하기 용이할 것이라고 판단해서 hostId는 큰 번호, participationId는 작은 번호로 저장되게 함.
  - 있다면 해당 채팅방의 번호를 반환
  - 있을 때 정상 채팅방이 아니라면 Error를 보냄

### 할 것
- 회원 추가시 Controller의 userId를 로그인한 회원의 번호로 받을 수 있게 추가
- ExceptionHandler 추가