### PR TITLE
feature - 채팅 설정 관련 url 변경

### DIFF
--- a/chatting-server/src/main/java/com/lastone/chat/config/StompConfig.java
+++ b/chatting-server/src/main/java/com/lastone/chat/config/StompConfig.java
@@ -14,8 +14,8 @@ public class StompConfig implements WebSocketMessageBrokerConfigurer {
     private String frontEndURL;
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/stomp/chat")
-                .setAllowedOrigins(frontEndURL)
+        registry.addEndpoint("/chat/stomp")
+                .setAllowedOrigins(frontEndURL, "http://localhost:8082")
                 .withSockJS();
     }
 

--- a/chatting-server/src/main/resources/templates/chat/chat.html
+++ b/chatting-server/src/main/resources/templates/chat/chat.html
@@ -186,7 +186,7 @@
             </div>`;
     }
   }
-  const sockJS = new SockJS("/stomp/chat");
+  const sockJS = new SockJS("/chat/stomp");
   const stomp = Stomp.over(sockJS);
 
   stomp.heartbeat.outgoing = 0; //Rabbit에선 heartbeat 안먹힌다고 함

--- a/core/src/main/java/com/lastone/core/config/SecurityConfig.java
+++ b/core/src/main/java/com/lastone/core/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
                 .authorizeRequests()
                 .antMatchers("/test").permitAll()
                 .antMatchers("/test/chat-room/**").permitAll()
-                .antMatchers("/stomp/**").permitAll()
+                .antMatchers("/chat/stomp/**").permitAll()
                 .antMatchers("/pub/chat/message/**").permitAll()
                 .antMatchers("/sub/chat/message/**").permitAll()
                 .antMatchers("/api/**").permitAll()


### PR DESCRIPTION
# 한 것
- 서버에서는 로드 밸런서가 https://www.last-one.xyz/chat 으로 chat으로 시작할 때에만 채팅 서버로 라우팅 시켜주기 때문에 
  stomp와 chat의 순서 변경