### PR TITLE
Hotfix: 마이페이지 요일 정보 데이터 타입 변경 및 정렬, 유효성 처리

### DIFF
--- a/api-server/src/main/java/com/lastone/apiserver/service/member/MemberServiceImpl.java
+++ b/api-server/src/main/java/com/lastone/apiserver/service/member/MemberServiceImpl.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.ObjectUtils;
 import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.Optional;
@@ -24,7 +25,6 @@ public class MemberServiceImpl implements MemberService {
 
     private final S3ServiceImpl s3Service;
 
-
     public Member findById(Long memberId) {
         return memberRepository.findById(memberId).orElseThrow(MemberNotFountException::new);
     }
@@ -33,10 +33,8 @@ public class MemberServiceImpl implements MemberService {
     public void update(Member member, MemberUpdateDto memberUpdateDto, MultipartFile profileImg) throws IOException {
         isDuplicatedNickname(memberUpdateDto.getNickname(), member.getNickname());
 
-        if (profileImg != null) {
-            if (member.getProfileUrl() != null) {
-                s3Service.delete(member.getProfileUrl());
-            }
+        if (!ObjectUtils.isEmpty(profileImg)) {
+            s3Service.delete(member.getProfileUrl());
             memberUpdateDto.setProfileUrl(s3Service.upload(profileImg));
         }
         member.update(memberUpdateDto);

--- a/core/src/main/java/com/lastone/core/domain/member/Day.java
+++ b/core/src/main/java/com/lastone/core/domain/member/Day.java
@@ -1,0 +1,67 @@
+package com.lastone.core.domain.member;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public enum Day {
+    MONDAY("월", 0),
+    TUESDAY("화", 1),
+    WEDNESDAY("수", 2),
+    THURSDAY("목", 3),
+    FRIDAY("금", 4),
+    SATURDAY("토", 5),
+    SUNDAY("일", 6);
+    private final String text;
+    private final int order;
+    Day(String text, int order) {
+        this.text = text;
+        this.order = order;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public static Day from(String text) {
+        for (Day day : Day.values()) {
+            if (day.getText().equals(text)) {
+                return day;
+            }
+        }
+        return null;
+    }
+
+    public static boolean isValidType(List<String> inputs) {
+        List<String> dayTexts = Arrays.stream(Day.values()).map(day -> day.text).collect(Collectors.toList());
+        for (String input : inputs) {
+            if (!dayTexts.contains(input.trim())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static boolean isDuplicatedDaysExist(List<String> inputs) {
+        HashSet<String> days = new HashSet<>();
+        for (String input : inputs) {
+            if (days.contains(input.trim())) {
+                return false;
+            }
+            days.add(input.trim());
+        }
+        return true;
+    }
+
+    public static String sortListToString(List<String> inputs) {
+        List<Day> days = new ArrayList<>();
+        for (String input : inputs) {
+            days.add(Day.from(input));
+        }
+        days.sort((Comparator.comparingInt(o -> o.order)));
+        StringBuffer sb = new StringBuffer();
+        for (Day day : days) {
+            sb.append(day.getText()).append(" ");
+        }
+        return sb.toString();
+    }
+}

--- a/core/src/main/java/com/lastone/core/domain/member/Member.java
+++ b/core/src/main/java/com/lastone/core/domain/member/Member.java
@@ -5,7 +5,6 @@ import com.lastone.core.repository.BaseTime;
 import com.lastone.core.util.BooleanToYNConverter;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
-
 import javax.persistence.*;
 
 @Entity
@@ -48,7 +47,7 @@ public class Member extends BaseTime {
         this.profileUrl = memberUpdateDto.getProfileUrl();
         this.workoutPurpose = memberUpdateDto.getWorkoutPurpose();
         this.workoutTime = memberUpdateDto.getWorkoutTime();
-        this.workoutDay = memberUpdateDto.getWorkoutDay();
+        this.workoutDay = Day.sortListToString(memberUpdateDto.getWorkoutDay());
         this.isEdited = true;
     }
 }

--- a/core/src/main/java/com/lastone/core/dto/member/MemberDto.java
+++ b/core/src/main/java/com/lastone/core/dto/member/MemberDto.java
@@ -3,6 +3,7 @@ package com.lastone.core.dto.member;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import java.util.List;
 
 @Getter
 @Builder
@@ -23,7 +24,7 @@ public class MemberDto {
 
     private String workoutTime;
 
-    private String workoutDay;
+    private List<String> workoutDay;
 
     private String status;
 

--- a/core/src/main/java/com/lastone/core/dto/member/MemberUpdateDto.java
+++ b/core/src/main/java/com/lastone/core/dto/member/MemberUpdateDto.java
@@ -3,8 +3,8 @@ package com.lastone.core.dto.member;
 import com.lastone.core.util.validator.member.WorkoutDay;
 import com.lastone.core.util.validator.member.WorkoutTime;
 import lombok.*;
-
 import javax.validation.constraints.*;
+import java.util.List;
 
 @Getter
 @Builder
@@ -27,12 +27,11 @@ public class MemberUpdateDto {
     private String workoutTime;
 
     @WorkoutDay
-    private String workoutDay;
+    private List<String> workoutDay;
 
     private String profileUrl;
 
     public void setProfileUrl(String url) {
         this.profileUrl = url;
     }
-
 }

--- a/core/src/main/java/com/lastone/core/mapper/mapper/MemberMapper.java
+++ b/core/src/main/java/com/lastone/core/mapper/mapper/MemberMapper.java
@@ -3,9 +3,11 @@ package com.lastone.core.mapper.mapper;
 import com.lastone.core.domain.member.Day;
 import com.lastone.core.domain.member.Member;
 import com.lastone.core.dto.member.MemberDto;
+import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -28,6 +30,9 @@ public interface MemberMapper extends GenericMapper<MemberDto, Member> {
 
     @Named("toWorkoutDayAsList")
     default List<String> toWorkoutDaysList(String workoutDay) {
+        if (StringUtils.isBlank(workoutDay)) {
+            return new ArrayList<>();
+        }
         return Arrays.asList(workoutDay.split(" "));
     }
 

--- a/core/src/main/java/com/lastone/core/mapper/mapper/MemberMapper.java
+++ b/core/src/main/java/com/lastone/core/mapper/mapper/MemberMapper.java
@@ -1,9 +1,12 @@
 package com.lastone.core.mapper.mapper;
 
+import com.lastone.core.domain.member.Day;
 import com.lastone.core.domain.member.Member;
 import com.lastone.core.dto.member.MemberDto;
 import org.mapstruct.Mapper;
-
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import java.util.Arrays;
 import java.util.List;
 
 
@@ -12,9 +15,24 @@ import java.util.List;
 public interface MemberMapper extends GenericMapper<MemberDto, Member> {
 
 
+    @Mapping(target = "workoutDay", source = "workoutDay", qualifiedByName = "toWorkoutDayAsList")
     @Override
     MemberDto toDto(Member member);
 
+    @Mapping(target = "workoutDay", source = "workoutDay", qualifiedByName = "toWorkoutDayListAsString")
+    @Override
+    Member toEntity(MemberDto dto);
+
     @Override
     List<MemberDto> toDto(List<Member> e);
+
+    @Named("toWorkoutDayAsList")
+    default List<String> toWorkoutDaysList(String workoutDay) {
+        return Arrays.asList(workoutDay.split(" "));
+    }
+
+    @Named("toWorkoutDayListAsString")
+    default String toWorkoutDayListAsString(List<String> workoutDays) {
+        return Day.sortListToString(workoutDays);
+    }
 }

--- a/core/src/main/java/com/lastone/core/util/validator/member/WorkoutDayValidator.java
+++ b/core/src/main/java/com/lastone/core/util/validator/member/WorkoutDayValidator.java
@@ -1,25 +1,18 @@
 package com.lastone.core.util.validator.member;
 
+import com.lastone.core.domain.member.Day;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import java.util.Arrays;
 import java.util.List;
 
-public class WorkoutDayValidator implements ConstraintValidator<WorkoutDay, String> {
-
-    private static final List<String> VALID_DAYS = Arrays.asList("월", "화", "수", "목", "금", "토", "일");
+public class WorkoutDayValidator implements ConstraintValidator<WorkoutDay, List<String>> {
 
     @Override
-    public boolean isValid(String value, ConstraintValidatorContext context) {
-        if (value == null) {
-            return true; // null values are considered valid
+    public boolean isValid(List<String> days, ConstraintValidatorContext context) {
+        if (days.isEmpty()) {
+            return true;
         }
-        String[] days = value.split(",");
-        for (String day : days) {
-            if (!VALID_DAYS.contains(day.trim())) {
-                return false;
-            }
-        }
-        return true;
+        return Day.isValidType(days) && Day.isDuplicatedDaysExist(days);
     }
 }


### PR DESCRIPTION
<한것>
프론트에서 요일 정보를 String이 아닌 배열로 주고 받는 방식을 원하기에 해당 형식으로 수정
요일이 중복되거나 요일 형식이 틀릴 경우 유효성 검증 처리
요일 순서가 옳바르지 않게 입력되어 정렬 되는 기능 추가
