### PR TITLE
Feature: 메인페이지의 오늘의 약속 API 기능 구현

### DIFF
--- a/api-server/src/main/java/com/lastone/apiserver/controller/PartnerController.java
+++ b/api-server/src/main/java/com/lastone/apiserver/controller/PartnerController.java
@@ -1,0 +1,29 @@
+package com.lastone.apiserver.controller;
+
+import com.lastone.apiserver.service.partner.PartnerService;
+import com.lastone.core.common.response.CommonResponse;
+import com.lastone.core.common.response.SuccessCode;
+import com.lastone.core.dto.partner.TodayPartnerDto;
+import com.lastone.core.security.principal.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/partner")
+public class PartnerController {
+
+    private final PartnerService partnerService;
+
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/today")
+    public ResponseEntity<CommonResponse<TodayPartnerDto>> getTodayPartner(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        TodayPartnerDto todayPartnerDto = partnerService.findTodayPartner(userDetails.getId());
+        return ResponseEntity.ok().body(CommonResponse.success(SuccessCode.TODAY_APPOINTMENT_INFO, todayPartnerDto));
+    }
+}

--- a/api-server/src/main/java/com/lastone/apiserver/exception/partner/PartnerControllerAdvice.java
+++ b/api-server/src/main/java/com/lastone/apiserver/exception/partner/PartnerControllerAdvice.java
@@ -1,0 +1,21 @@
+package com.lastone.apiserver.exception.partner;
+
+import com.lastone.core.common.response.CommonResponse;
+import com.lastone.core.common.response.ErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class PartnerControllerAdvice {
+    @ExceptionHandler(PartnerException.class)
+    public ResponseEntity<Object> globalExceptionHandler(PartnerException e) {
+        return handleExceptionInternal(e);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(PartnerException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(CommonResponse.fail(errorCode));
+    }
+}

--- a/api-server/src/main/java/com/lastone/apiserver/exception/partner/PartnerException.java
+++ b/api-server/src/main/java/com/lastone/apiserver/exception/partner/PartnerException.java
@@ -1,0 +1,10 @@
+package com.lastone.apiserver.exception.partner;
+
+import com.lastone.core.common.exception.LastOneException;
+import com.lastone.core.common.response.ErrorCode;
+
+public class PartnerException extends LastOneException {
+    public PartnerException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/api-server/src/main/java/com/lastone/apiserver/exception/partner/TodayPartnerNotFoundException.java
+++ b/api-server/src/main/java/com/lastone/apiserver/exception/partner/TodayPartnerNotFoundException.java
@@ -1,0 +1,9 @@
+package com.lastone.apiserver.exception.partner;
+
+import com.lastone.core.common.response.ErrorCode;
+
+public class TodayPartnerNotFoundException extends PartnerException {
+    public TodayPartnerNotFoundException() {
+        super(ErrorCode.TODAY_PARTNER_NOT_FOUND);
+    }
+}

--- a/api-server/src/main/java/com/lastone/apiserver/service/partner/PartnerService.java
+++ b/api-server/src/main/java/com/lastone/apiserver/service/partner/PartnerService.java
@@ -1,0 +1,7 @@
+package com.lastone.apiserver.service.partner;
+
+import com.lastone.core.dto.partner.TodayPartnerDto;
+
+public interface PartnerService {
+    TodayPartnerDto findTodayPartner(Long memberId);
+}

--- a/api-server/src/main/java/com/lastone/apiserver/service/partner/PartnerServiceImpl.java
+++ b/api-server/src/main/java/com/lastone/apiserver/service/partner/PartnerServiceImpl.java
@@ -1,0 +1,65 @@
+package com.lastone.apiserver.service.partner;
+
+import com.lastone.apiserver.exception.partner.TodayPartnerNotFoundException;
+import com.lastone.core.domain.application.Application;
+import com.lastone.core.domain.application.ApplicationStatus;
+import com.lastone.core.domain.member.Member;
+import com.lastone.core.domain.recruitment.Recruitment;
+import com.lastone.core.dto.partner.TodayPartnerDto;
+import com.lastone.core.repository.application.ApplicationRepository;
+import com.lastone.core.repository.recruitment.RecruitmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PartnerServiceImpl implements PartnerService {
+
+    private final RecruitmentRepository recruitmentRepository;
+    private final ApplicationRepository applicationRepository;
+
+    @Override
+    public TodayPartnerDto findTodayPartner(Long memberId) {
+
+        // 모집글에 매칭된 파트너 먼저 조회
+        Recruitment recruitment = recruitmentRepository.findOneCompleteStatusAtTodayByMemberId(memberId);
+        if (recruitment != null) {
+            Member partner = findSuccessApplicant(recruitment.getApplications());
+            if (partner != null) {
+                return TodayPartnerDto.builder()
+                        .recruitmentId(recruitment.getId())
+                        .partnerName(partner.getNickname())
+                        .workoutPart(recruitment.getWorkoutPart())
+                        .startedAt(recruitment.getStartedAt())
+                        .gym(recruitment.getGym().getName())
+                        .build();
+            }
+        }
+
+        // 모집글에 매칭된 파트너가 없으면 요청한 신청이 Success 모집글 작성자 정보 조회
+        Application application = applicationRepository.findMyTodaySuccessApplication(memberId);
+        if (application != null) {
+            return TodayPartnerDto.builder()
+                    .recruitmentId(application.getRecruitment().getId())
+                    .partnerName(application.getRecruitment().getMember().getNickname())
+                    .workoutPart(application.getRecruitment().getWorkoutPart())
+                    .startedAt(application.getRecruitment().getStartedAt())
+                    .gym(application.getRecruitment().getGym().getName())
+                    .build();
+        }
+
+        // 요청 받은 신청에도 매칭 내역이 없고, 요청 한 신청에도 매칭 내역이 없으면 예외처리
+        throw new TodayPartnerNotFoundException();
+    }
+
+    private Member findSuccessApplicant(List<Application> applications) {
+        return applications.stream()
+                .filter(application -> application.getStatus().equals(ApplicationStatus.SUCCESS))
+                .map(Application::getApplicant)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/core/src/main/java/com/lastone/core/common/response/ErrorCode.java
+++ b/core/src/main/java/com/lastone/core/common/response/ErrorCode.java
@@ -74,6 +74,9 @@ public enum ErrorCode {
   ALREADY_APPLIED_RECRUITMENT(400, "A006", "동일한 모집글에 중복 신청은 불가능합니다."),
   ALREADY_MATCHING_COMPLETE(400, "A007", "이미 매칭이 완료된 모집글의 신청 취소는 불가능합니다."),
 
+  /* 파트너 예외 */
+  TODAY_PARTNER_NOT_FOUND(404, "P001", "오늘 파트너와의 약속이 존재하지 않습니다."),
+
   /* 글로벌 예외 */
   HTTP_REQUEST_METHOD_NOT_SUPPORTED(405, "G001", "지원하지 않는 HTTP 메서드 형식입니다."),
   HTTP_MEDIA_TYPE_EXCEPTION(415, "G002", "지원하지 않는 미디어 타입입니다. Json 혹은 Form-Data 형식인지 확인해주세요."),

--- a/core/src/main/java/com/lastone/core/common/response/SuccessCode.java
+++ b/core/src/main/java/com/lastone/core/common/response/SuccessCode.java
@@ -33,6 +33,9 @@ public enum SuccessCode {
     APPLICATION_MATCHING_CANCEL("매칭된 파트너와의 운동을 취소하였습니다."),
     APPLICATION_REQUEST_CANCEL("요청한 신청이 취소되었습니다."),
 
+    /* 파트너 */
+    TODAY_APPOINTMENT_INFO("오늘의 약속 정보가 조회되었습니다."),
+
 
     ;
 

--- a/core/src/main/java/com/lastone/core/dto/partner/TodayPartnerDto.java
+++ b/core/src/main/java/com/lastone/core/dto/partner/TodayPartnerDto.java
@@ -1,0 +1,29 @@
+package com.lastone.core.dto.partner;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.lastone.core.domain.recruitment.WorkoutPart;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class TodayPartnerDto {
+
+    private Long recruitmentId;
+
+    private String partnerName;
+
+    private WorkoutPart workoutPart;
+
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd 'T' HH:mm")
+    private LocalDateTime startedAt;
+
+    private String gym;
+}

--- a/core/src/main/java/com/lastone/core/repository/application/ApplicationRepositoryCustom.java
+++ b/core/src/main/java/com/lastone/core/repository/application/ApplicationRepositoryCustom.java
@@ -14,4 +14,6 @@ public interface ApplicationRepositoryCustom {
     List<Application> findAllByRecruitmentId(Long recruitmentId);
 
     void updateStatus(Long recruitmentId, Long applicationId);
+
+    Application findMyTodaySuccessApplication(Long memberId);
 }

--- a/core/src/main/java/com/lastone/core/repository/application/ApplicationRepositoryImpl.java
+++ b/core/src/main/java/com/lastone/core/repository/application/ApplicationRepositoryImpl.java
@@ -129,4 +129,22 @@ public class ApplicationRepositoryImpl implements ApplicationRepositoryCustom{
         em.flush();
         em.clear();
     }
+
+    @Override
+    public Application findMyTodaySuccessApplication(Long memberId) {
+
+        LocalDateTime today = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0).withNano(0);
+        LocalDateTime tomorrow = today.plusDays(1);
+
+        return queryFactory
+                .selectFrom(application)
+                .where(
+                        application.applicant.id.eq(memberId),
+                        application.status.eq(ApplicationStatus.SUCCESS),
+                        application.recruitment.startedAt.between(today, tomorrow))
+                .leftJoin(application.recruitment, recruitment).fetchJoin()
+                .leftJoin(recruitment.gym, gym).fetchJoin()
+                .leftJoin(recruitment.member, member).fetchJoin()
+                .fetchFirst();
+    }
 }

--- a/core/src/main/java/com/lastone/core/repository/recruitment/RecruitmentRepositoryCustom.java
+++ b/core/src/main/java/com/lastone/core/repository/recruitment/RecruitmentRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.lastone.core.repository.recruitment;
 
+import com.lastone.core.domain.recruitment.Recruitment;
 import com.lastone.core.dto.recruitment.RecruitmentDetailDto;
 import com.lastone.core.dto.recruitment.RecruitmentListDto;
 import com.lastone.core.dto.recruitment.RecruitmentSearchCondition;
@@ -9,6 +10,10 @@ import java.util.List;
 public interface RecruitmentRepositoryCustom {
 
     Slice<RecruitmentListDto> getListDto(RecruitmentSearchCondition searchCondition);
+
     RecruitmentDetailDto getDetailDto(Long recruitmentId);
+
     List<RecruitmentListDto> getListDtoInMainPage();
+
+    Recruitment findOneCompleteStatusAtTodayByMemberId(Long memberId);
 }

--- a/core/src/main/java/com/lastone/core/repository/recruitment/RecruitmentRepositoryImpl.java
+++ b/core/src/main/java/com/lastone/core/repository/recruitment/RecruitmentRepositoryImpl.java
@@ -1,9 +1,6 @@
 package com.lastone.core.repository.recruitment;
 
-import com.lastone.core.domain.recruitment.PreferGender;
-import com.lastone.core.domain.recruitment.Recruitment;
-import com.lastone.core.domain.recruitment.RecruitmentStatus;
-import com.lastone.core.domain.recruitment.WorkoutPart;
+import com.lastone.core.domain.recruitment.*;
 import com.lastone.core.dto.recruitment.QRecruitmentDetailDto;
 import com.lastone.core.dto.recruitment.RecruitmentDetailDto;
 import com.lastone.core.dto.recruitment.RecruitmentListDto;
@@ -15,6 +12,7 @@ import org.springframework.data.domain.*;
 import org.springframework.util.ObjectUtils;
 import java.time.LocalDateTime;
 import java.util.List;
+import static com.lastone.core.domain.application.QApplication.application;
 import static com.lastone.core.domain.gym.QGym.gym;
 import static com.lastone.core.domain.member.QMember.member;
 import static com.lastone.core.domain.recruitment.QRecruitment.recruitment;
@@ -104,6 +102,23 @@ public class RecruitmentRepositoryImpl implements RecruitmentRepositoryCustom{
                 .fetch();
 
         return checkLastPage(pageable, content);
+    }
+
+    @Override
+    public Recruitment findOneCompleteStatusAtTodayByMemberId(Long memberId) {
+
+        LocalDateTime today = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0).withNano(0);
+        LocalDateTime tomorrow = today.plusDays(1);
+
+        return queryFactory
+                .selectFrom(recruitment)
+                .where(
+                        recruitment.member.id.eq(memberId),
+                        recruitment.recruitmentStatus.eq(RecruitmentStatus.COMPLETE),
+                        recruitment.startedAt.between(today, tomorrow))
+                .leftJoin(recruitment.applications, application).fetchJoin()
+                .leftJoin(recruitment.gym, gym).fetchJoin()
+                .fetchFirst();
     }
 
     private BooleanExpression eqWorkoutPart(WorkoutPart workoutPart) {


### PR DESCRIPTION
<한것>

오늘의 약속 API 기능 구현을 위해 경우의 수 2가지로 나누어서 진행

1. 자신의 모집글의 상태가 '모집 완료' 이고 모집글에 등록된 운동 시작 시간이 오늘일 경우 매칭이 완료된 신청자의 정보를 가져온다.

2. 1의 조건을 만족하는 경우가 없을 때, 자신이 신청한  모집글의 운동시작 시간이 오늘일고, 신청 상태가 'SUCCESS'일 경우 모집글 작성자의 정보를 가져온다.

크게 2가지 경우로 나누어 API 기능 구현을 완료했습니다.