### PR TITLE
Feature: 파트너 목록 조회 관련 API 구현

### DIFF
--- a/api-server/src/main/java/com/lastone/apiserver/controller/PartnerController.java
+++ b/api-server/src/main/java/com/lastone/apiserver/controller/PartnerController.java
@@ -3,6 +3,7 @@ package com.lastone.apiserver.controller;
 import com.lastone.apiserver.service.partner.PartnerService;
 import com.lastone.core.common.response.CommonResponse;
 import com.lastone.core.common.response.SuccessCode;
+import com.lastone.core.dto.partner.PartnerHistoryDto;
 import com.lastone.core.dto.partner.TodayPartnerDto;
 import com.lastone.core.security.principal.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,5 +27,12 @@ public class PartnerController {
     public ResponseEntity<CommonResponse<TodayPartnerDto>> getTodayPartner(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         TodayPartnerDto todayPartnerDto = partnerService.findTodayPartner(userDetails.getId());
         return ResponseEntity.ok().body(CommonResponse.success(SuccessCode.TODAY_APPOINTMENT_INFO, todayPartnerDto));
+    }
+
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/history")
+    public ResponseEntity<CommonResponse> getPartnerHistory(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        List<PartnerHistoryDto> partnerHistoryList = partnerService.findPartnerHistoryList(userDetails.getId());
+        return ResponseEntity.ok().body(CommonResponse.success(SuccessCode.PARTNER_HISTORY_LIST, partnerHistoryList));
     }
 }

--- a/api-server/src/main/java/com/lastone/apiserver/exception/partner/PartnerHistoryNotFoundException.java
+++ b/api-server/src/main/java/com/lastone/apiserver/exception/partner/PartnerHistoryNotFoundException.java
@@ -1,0 +1,9 @@
+package com.lastone.apiserver.exception.partner;
+
+import com.lastone.core.common.response.ErrorCode;
+
+public class PartnerHistoryNotFoundException extends PartnerException {
+    public PartnerHistoryNotFoundException() {
+        super(ErrorCode.PARTNER_HISTORY_NOT_FOUND);
+    }
+}

--- a/api-server/src/main/java/com/lastone/apiserver/service/partner/PartnerService.java
+++ b/api-server/src/main/java/com/lastone/apiserver/service/partner/PartnerService.java
@@ -1,7 +1,12 @@
 package com.lastone.apiserver.service.partner;
 
+import com.lastone.core.dto.partner.PartnerHistoryDto;
 import com.lastone.core.dto.partner.TodayPartnerDto;
+import java.util.List;
 
 public interface PartnerService {
+
     TodayPartnerDto findTodayPartner(Long memberId);
+
+    List<PartnerHistoryDto> findPartnerHistoryList(Long memberId);
 }

--- a/core/src/main/java/com/lastone/core/common/response/ErrorCode.java
+++ b/core/src/main/java/com/lastone/core/common/response/ErrorCode.java
@@ -76,6 +76,7 @@ public enum ErrorCode {
 
   /* 파트너 예외 */
   TODAY_PARTNER_NOT_FOUND(404, "P001", "오늘 파트너와의 약속이 존재하지 않습니다."),
+  PARTNER_HISTORY_NOT_FOUND(404, "P002", "매칭된 파트너 목록이 없습니다."),
 
   /* 글로벌 예외 */
   HTTP_REQUEST_METHOD_NOT_SUPPORTED(405, "G001", "지원하지 않는 HTTP 메서드 형식입니다."),

--- a/core/src/main/java/com/lastone/core/common/response/SuccessCode.java
+++ b/core/src/main/java/com/lastone/core/common/response/SuccessCode.java
@@ -35,8 +35,7 @@ public enum SuccessCode {
 
     /* 파트너 */
     TODAY_APPOINTMENT_INFO("오늘의 약속 정보가 조회되었습니다."),
-
-
+    PARTNER_HISTORY_LIST("운동 파트너 목록 조회가 완료되었습니다."),
     ;
 
     private String message;

--- a/core/src/main/java/com/lastone/core/dto/partner/PartnerHistoryDto.java
+++ b/core/src/main/java/com/lastone/core/dto/partner/PartnerHistoryDto.java
@@ -1,0 +1,28 @@
+package com.lastone.core.dto.partner;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class PartnerHistoryDto {
+
+    private Long id;
+
+    private String nickname;
+
+    private String profileUrl;
+
+    private String gender;
+
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
+    private LocalDateTime workoutDate;
+}

--- a/core/src/main/java/com/lastone/core/repository/application/ApplicationRepositoryCustom.java
+++ b/core/src/main/java/com/lastone/core/repository/application/ApplicationRepositoryCustom.java
@@ -16,4 +16,6 @@ public interface ApplicationRepositoryCustom {
     void updateStatus(Long recruitmentId, Long applicationId);
 
     Application findMyTodaySuccessApplication(Long memberId);
+
+    List<Application> findAllSuccessStatusBeforeToday(Long memberId);
 }

--- a/core/src/main/java/com/lastone/core/repository/application/ApplicationRepositoryImpl.java
+++ b/core/src/main/java/com/lastone/core/repository/application/ApplicationRepositoryImpl.java
@@ -115,13 +115,16 @@ public class ApplicationRepositoryImpl implements ApplicationRepositoryCustom{
         queryFactory
                 .update(application)
                 .set(application.status, ApplicationStatus.SUCCESS)
-                .where(application.id.eq(successApplicationId))
+                .where(
+                        application.id.eq(successApplicationId),
+                        application.recruitment.id.eq(recruitmentId))
                 .execute();
 
         queryFactory
                 .update(application)
                 .set(application.status, ApplicationStatus.FAILURE)
                 .where(
+                        application.recruitment.id.eq(recruitmentId),
                         application.id.ne(successApplicationId),
                         application.status.ne(ApplicationStatus.CANCLE))
                 .execute();
@@ -146,5 +149,22 @@ public class ApplicationRepositoryImpl implements ApplicationRepositoryCustom{
                 .leftJoin(recruitment.gym, gym).fetchJoin()
                 .leftJoin(recruitment.member, member).fetchJoin()
                 .fetchFirst();
+    }
+
+    @Override
+    public List<Application> findAllSuccessStatusBeforeToday(Long memberId) {
+
+        LocalDateTime today = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0).withNano(0);
+
+        return queryFactory
+                .selectFrom(application)
+                .where(
+                        application.applicant.id.eq(memberId),
+                        application.status.eq(ApplicationStatus.SUCCESS),
+                        application.recruitment.startedAt.loe(today))
+                .leftJoin(application.recruitment, recruitment).fetchJoin()
+                .leftJoin(recruitment.member, member).fetchJoin()
+                .orderBy(application.recruitment.startedAt.asc())
+                .fetch();
     }
 }

--- a/core/src/main/java/com/lastone/core/repository/recruitment/RecruitmentRepositoryCustom.java
+++ b/core/src/main/java/com/lastone/core/repository/recruitment/RecruitmentRepositoryCustom.java
@@ -16,4 +16,6 @@ public interface RecruitmentRepositoryCustom {
     List<RecruitmentListDto> getListDtoInMainPage();
 
     Recruitment findOneCompleteStatusAtTodayByMemberId(Long memberId);
+
+    List<Recruitment> findAllCompleteStatusBeforeToday(Long memberId);
 }

--- a/core/src/main/java/com/lastone/core/repository/recruitment/RecruitmentRepositoryImpl.java
+++ b/core/src/main/java/com/lastone/core/repository/recruitment/RecruitmentRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.lastone.core.repository.recruitment;
 
+import com.lastone.core.domain.application.ApplicationStatus;
 import com.lastone.core.domain.recruitment.*;
 import com.lastone.core.dto.recruitment.QRecruitmentDetailDto;
 import com.lastone.core.dto.recruitment.RecruitmentDetailDto;
@@ -119,6 +120,22 @@ public class RecruitmentRepositoryImpl implements RecruitmentRepositoryCustom{
                 .leftJoin(recruitment.applications, application).fetchJoin()
                 .leftJoin(recruitment.gym, gym).fetchJoin()
                 .fetchFirst();
+    }
+
+    @Override
+    public List<Recruitment> findAllCompleteStatusBeforeToday(Long memberId) {
+
+        LocalDateTime now = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0).withNano(0);
+
+        return queryFactory
+                .selectFrom(recruitment)
+                .where(
+                        recruitment.member.id.eq(memberId),
+                        recruitment.recruitmentStatus.eq(RecruitmentStatus.COMPLETE),
+                        recruitment.startedAt.loe(now))
+                .leftJoin(recruitment.applications, application).fetchJoin()
+                .orderBy(recruitment.startedAt.asc())
+                .fetch();
     }
 
     private BooleanExpression eqWorkoutPart(WorkoutPart workoutPart) {


### PR DESCRIPTION
<한것>

- 매칭 완료 시 신청 값의 상태 변경 잘못된 부분 로직 수정

- 파트너 목록 조회 관련 분기 처리
1. 내가 쓴 모집글의 신청들 중에 신청 상태값이 Success이고 오늘 기준 이전의 운동시작 시간일 경우 해당하는  멤버의 정보를 파트너 리스트에 저장
2. 내가 신청한 상태가 Success이고 모집글의 운동시작시간이 오늘 기준 이전일 경우 모집글 작성자의 멤버 정보를 파트너 리스트에 저장

- 파트너 목록 조회 관련 예외 처리 