### PR TITLE
Feature/ OAuth2 로그인 시 초기 닉네임 설정 로직 추가

### DIFF
--- a/api-server/src/main/java/com/lastone/apiserver/oauth2/kakao/KakaoOauth2Service.java
+++ b/api-server/src/main/java/com/lastone/apiserver/oauth2/kakao/KakaoOauth2Service.java
@@ -39,10 +39,13 @@ public class KakaoOauth2Service implements Oauth2Service {
         KakaoOauth2UserInfo profile = getProfile(token);
         Optional<Member> member = memberRepository.findByEmail(profile.getEmail());
         if(member.isEmpty()) {
-            memberRepository.save(Member.builder()
+            Member saveMember = memberRepository.save(Member.builder()
                     .email(profile.getEmail())
                     .gender(profile.getGender())
                     .build());
+
+            String nickname = "#" + saveMember.getId();
+            saveMember.initNickname(nickname);
         }
         TokenResponse tokens = jwtProvider.createToken(profile.getEmail(), requestURI);
         redisTemplate.opsForValue()

--- a/core/src/main/java/com/lastone/core/domain/member/Member.java
+++ b/core/src/main/java/com/lastone/core/domain/member/Member.java
@@ -56,4 +56,8 @@ public class Member extends BaseTime {
         this.workoutDay = Day.sortListToString(memberUpdateDto.getWorkoutDay());
         this.isEdited = true;
     }
+
+    public void initNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }


### PR DESCRIPTION
- 회원 정보가 없으면, 회원 저장 후 초기 닉네임을 "#" + pk 값으로 설정 