### PR TITLE
[Fix] : 받은 신청 응답 데이터 상태값 추가 작업 

### DIFF
--- a/api-server/src/main/java/com/lastone/apiserver/service/application/ApplicationServiceImpl.java
+++ b/api-server/src/main/java/com/lastone/apiserver/service/application/ApplicationServiceImpl.java
@@ -20,7 +20,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -32,7 +31,9 @@ import java.util.stream.Collectors;
 public class ApplicationServiceImpl implements ApplicationService {
 
     private final ApplicationRepository applicationRepository;
+
     private final MemberRepository memberRepository;
+
     private final RecruitmentRepository recruitmentRepository;
 
     private final NotificationRepository notificationRepository;

--- a/core/src/main/java/com/lastone/core/domain/application/Application.java
+++ b/core/src/main/java/com/lastone/core/domain/application/Application.java
@@ -38,6 +38,6 @@ public class Application extends BaseTime {
     }
 
     public void cancel() {
-        this.status = ApplicationStatus.CANCLE;
+        this.status = ApplicationStatus.CANCEL;
     }
 }

--- a/core/src/main/java/com/lastone/core/domain/application/ApplicationStatus.java
+++ b/core/src/main/java/com/lastone/core/domain/application/ApplicationStatus.java
@@ -3,7 +3,7 @@ package com.lastone.core.domain.application;
 public enum ApplicationStatus {
 
     WAITING("대기중"),
-    CANCLE("신청 취소"),
+    CANCEL("신청 취소"),
     FAILURE("매칭 실패"),
     SUCCESS("매칭 성공");
 

--- a/core/src/main/java/com/lastone/core/dto/applicaation/ApplicationDto.java
+++ b/core/src/main/java/com/lastone/core/dto/applicaation/ApplicationDto.java
@@ -3,6 +3,7 @@ package com.lastone.core.dto.applicaation;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.lastone.core.domain.application.ApplicationStatus;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 import lombok.ToString;
@@ -13,22 +14,29 @@ import java.time.LocalDateTime;
 public class ApplicationDto {
 
     private final Long applicationId;
+
     private final Long applicantId;
+
     private final String nickname;
+
     private final String profileUrl;
+
     private final String gender;
+
+    private ApplicationStatus status;
 
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd 'T' HH:mm")
     private LocalDateTime applicationDate;
 
     @QueryProjection
-    public ApplicationDto(Long applicationId, Long applicantId, String nickname, String profileUrl, String gender, LocalDateTime applicationDate) {
+    public ApplicationDto(Long applicationId, Long applicantId, String nickname, String profileUrl, String gender, ApplicationStatus status, LocalDateTime applicationDate) {
         this.applicationId = applicationId;
         this.applicantId = applicantId;
         this.nickname = nickname;
         this.profileUrl = profileUrl;
         this.gender = gender;
+        this.status = status;
         this.applicationDate = applicationDate;
     }
 }

--- a/core/src/main/java/com/lastone/core/dto/applicaation/ApplicationReceivedDto.java
+++ b/core/src/main/java/com/lastone/core/dto/applicaation/ApplicationReceivedDto.java
@@ -12,12 +12,17 @@ import java.util.List;
 @Getter
 @ToString
 public class ApplicationReceivedDto {
+
     private final Long id;
+
     private final String title;
+
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd 'T' HH:mm")
     private final LocalDateTime startedAt;
+
     private final String gym;
+
     private List<ApplicationDto> applications;
 
     @QueryProjection

--- a/core/src/main/java/com/lastone/core/repository/application/ApplicationRepositoryImpl.java
+++ b/core/src/main/java/com/lastone/core/repository/application/ApplicationRepositoryImpl.java
@@ -19,7 +19,9 @@ import static com.lastone.core.domain.recruitment.QRecruitment.recruitment;
 public class ApplicationRepositoryImpl implements ApplicationRepositoryCustom{
 
     private final JPAQueryFactory queryFactory;
+
     private final EntityManager em;
+
     private static final int ONE_DAY = 1;
 
     @Override
@@ -57,6 +59,7 @@ public class ApplicationRepositoryImpl implements ApplicationRepositoryCustom{
                             application.applicant.nickname,
                             application.applicant.profileUrl,
                             application.applicant.gender,
+                            application.status,
                             application.createdAt))
                     .from(application)
                     .where(application.recruitment.id.eq(recruitmentId))
@@ -126,7 +129,7 @@ public class ApplicationRepositoryImpl implements ApplicationRepositoryCustom{
                 .where(
                         application.recruitment.id.eq(recruitmentId),
                         application.id.ne(successApplicationId),
-                        application.status.ne(ApplicationStatus.CANCLE))
+                        application.status.ne(ApplicationStatus.CANCEL))
                 .execute();
 
         em.flush();

--- a/core/src/main/java/com/lastone/core/repository/recruitment/RecruitmentRepository.java
+++ b/core/src/main/java/com/lastone/core/repository/recruitment/RecruitmentRepository.java
@@ -2,13 +2,13 @@ package com.lastone.core.repository.recruitment;
 
 import com.lastone.core.domain.recruitment.Recruitment;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface RecruitmentRepository extends JpaRepository<Recruitment, Long>, RecruitmentRepositoryCustom {
 
     @Query("select r from Recruitment r where r.id = :id and r.isDeleted = false")
-    Optional<Recruitment> findByIdAndDeletedIsFalse(Long id);
+    Optional<Recruitment> findByIdAndDeletedIsFalse(@Param("id") Long id);
 }


### PR DESCRIPTION
## What is this PR?🔍
받은 신청 페이지 데이터에 신청 상태값이 누락되어 추가하는 작업을 진행하였습니다.

<br/>

## 📑 작업 사항
프런트에서 신청 관련 로직 처리를 위한 신청 상태 값을 응답데이터에 추가하였습니다.
모집글 조회 과정에서 Param 어노테이션 누락으로 인한 에러를 해결하였습니다.

<br/>

## 🖥️ 스크린샷

![image](https://github.com/Sinchone/LastOne_BE/assets/96610382/b463db3a-d918-489e-8cf5-2e3717593b1e)
