### PR TITLE
[Fix]: 모집글 상세 글쓴이 성별 정보 반영

### DIFF
--- a/core/src/main/java/com/lastone/core/dto/recruitment/RecruitmentDetailDto.java
+++ b/core/src/main/java/com/lastone/core/dto/recruitment/RecruitmentDetailDto.java
@@ -24,6 +24,7 @@ public class RecruitmentDetailDto {
 
     private Long memberId;
     private String nickname;
+    private String gender;
     private String profileUrl;
     private String workoutPurpose;
     private SbdDto sbd;
@@ -53,6 +54,7 @@ public class RecruitmentDetailDto {
                 .memberId(recruitment.getMember().getId())
                 .nickname(recruitment.getMember().getNickname())
                 .profileUrl(recruitment.getMember().getProfileUrl())
+                .gender(recruitment.getMember().getGender())
                 .workoutPurpose(recruitment.getMember().getWorkoutPurpose())
                 .imgUrls(toImgUrls(recruitment.getRecruitmentImgs()))
                 .build();


### PR DESCRIPTION
## What is this PR?🔍
- 모집글 상세 조회에서 글쓴이 성별이 반영안되는 문제를 해결하였습니다.