### PR TITLE
[Fix]: 모집글 및 마이페이지 세부 버그 및 에러 해결

### DIFF
--- a/api-server/src/main/java/com/lastone/apiserver/controller/MyPageController.java
+++ b/api-server/src/main/java/com/lastone/apiserver/controller/MyPageController.java
@@ -26,7 +26,7 @@ public class MyPageController {
     private final MyPageService myPageService;
 
     @GetMapping("/nickname-check")
-    public ResponseEntity<Object> isDuplicatedNickname(String nickname) {
+    public ResponseEntity<Object> isDuplicatedNickname(@RequestParam String nickname) {
         NicknameCheckDto result = myPageService.isDuplicatedNickname(nickname);
         return ResponseEntity.ok().body(CommonResponse.success(result, SuccessCode.VALIDATE_NICKNAME.getMessage()));
     }

--- a/api-server/src/main/java/com/lastone/apiserver/service/recruitment/RecruitmentServiceImpl.java
+++ b/api-server/src/main/java/com/lastone/apiserver/service/recruitment/RecruitmentServiceImpl.java
@@ -65,7 +65,8 @@ public class RecruitmentServiceImpl implements RecruitmentService {
 
     @Override
     public RecruitmentDetailDto getDetail(Long recruitmentId) {
-        RecruitmentDetailDto recruitmentDetailDto = recruitmentRepository.getDetailDto(recruitmentId).orElseThrow(RecruitmentNotFoundException::new);
+        Recruitment recruitment = recruitmentRepository.getDetail(recruitmentId).orElseThrow(RecruitmentNotFoundException::new);
+        RecruitmentDetailDto recruitmentDetailDto = RecruitmentDetailDto.toDto(recruitment);
         recruitmentDetailDto.setSbdDto(sbdRepository.findLatestRecordByMemberId(recruitmentDetailDto.getMemberId()));
         return recruitmentDetailDto;
     }

--- a/core/src/main/java/com/lastone/core/dto/recruitment/RecruitmentIdDto.java
+++ b/core/src/main/java/com/lastone/core/dto/recruitment/RecruitmentIdDto.java
@@ -1,5 +1,8 @@
 package com.lastone.core.dto.recruitment;
 
+import lombok.Getter;
+
+@Getter
 public class RecruitmentIdDto {
 
     private final Long id;

--- a/core/src/main/java/com/lastone/core/repository/recruitment/RecruitmentRepositoryCustom.java
+++ b/core/src/main/java/com/lastone/core/repository/recruitment/RecruitmentRepositoryCustom.java
@@ -1,7 +1,6 @@
 package com.lastone.core.repository.recruitment;
 
 import com.lastone.core.domain.recruitment.Recruitment;
-import com.lastone.core.dto.recruitment.RecruitmentDetailDto;
 import com.lastone.core.dto.recruitment.RecruitmentListDto;
 import com.lastone.core.dto.recruitment.RecruitmentSearchCondition;
 import org.springframework.data.domain.Slice;
@@ -12,7 +11,7 @@ public interface RecruitmentRepositoryCustom {
 
     Slice<RecruitmentListDto> getListDto(RecruitmentSearchCondition searchCondition);
 
-    Optional<RecruitmentDetailDto> getDetailDto(Long recruitmentId);
+    Optional<Recruitment> getDetail(Long recruitmentId);
 
     List<RecruitmentListDto> getListDtoInMainPage();
 

--- a/core/src/main/java/com/lastone/core/repository/recruitment/RecruitmentRepositoryImpl.java
+++ b/core/src/main/java/com/lastone/core/repository/recruitment/RecruitmentRepositoryImpl.java
@@ -35,7 +35,7 @@ public class RecruitmentRepositoryImpl implements RecruitmentRepositoryCustom{
     private static final int DEFAULT_MAIN_PAGE_SIZE = 9;
 
     @Override
-    public Optional<RecruitmentDetailDto> getDetailDto(Long recruitmentId) {
+    public Optional<Recruitment> getDetail(Long recruitmentId) {
 
         Recruitment findRecruitment = queryFactory
                 .selectFrom(recruitment)
@@ -48,7 +48,7 @@ public class RecruitmentRepositoryImpl implements RecruitmentRepositoryCustom{
                 )
                 .fetchOne();
 
-        return Optional.of(RecruitmentDetailDto.toDto(findRecruitment));
+        return Optional.ofNullable(findRecruitment);
     }
 
     @Override


### PR DESCRIPTION
## What is this PR?🔍
- 모집글 작성 후 모집글 id 반환이  Json 컨버터 문제로 에러가 생기는 문제를 해결하였습니다.
- 닉네임 중복 검증 관련 쿼리파리미터 nickname을 필수 입력 값으로 지정하는 어노테이션을 추가하였습니다.
- 모집글 상세 조회시 해당 모집글 id로 되어있는 모집글이 없을 경우 예외 처리가 정상적으로 되도록 수정하였습니다.