### PR TITLE
[Fix]: 채팅 API 로직 관련 수정

### DIFF
--- a/chatting-server/src/main/java/com/lastone/chat/repository/ChatMessageRepository.java
+++ b/chatting-server/src/main/java/com/lastone/chat/repository/ChatMessageRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import java.util.List;
 
 public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
-    List<ChatMessage> findByRoomId(String roomId);
+    List<ChatMessage> findByRoomIdOrderByCreatedAtAsc(String roomId);
 }

--- a/core/src/main/java/com/lastone/core/util/mapper/MemberMapper.java
+++ b/core/src/main/java/com/lastone/core/util/mapper/MemberMapper.java
@@ -22,6 +22,7 @@ public interface MemberMapper extends GenericMapper<MemberDto, Member> {
     MemberDto toDto(Member member);
 
     @Mapping(target = "workoutDay", source = "workoutDay", qualifiedByName = "toWorkoutDayListAsString")
+    @Mapping(target = "notificationList", ignore = true)
     @Override
     Member toEntity(MemberDto dto);
 


### PR DESCRIPTION
## 한 것
- 채팅방 상세 관련 메세지 응답할 때 기존의 시간순 정렬 방식에서 날짜 전체 정렬 순으로 변경
- 채팅방 리스트 관련 API에서 읽지 않은 메세지 카운트 할 때, API 조회한 유저를 기준으로 카운트하는 방식으로 변경
