### PR TITLE
[Fix]: 메세지 구독 방식 변경 및 배포 서버에서 소켓 연결 가능하게 설정

### DIFF
--- a/chatting-server/src/main/java/com/lastone/chat/config/ChatMessageListener.java
+++ b/chatting-server/src/main/java/com/lastone/chat/config/ChatMessageListener.java
@@ -33,7 +33,7 @@ public class ChatMessageListener {
             log.info("newMessageResponseDto    :    {}", newMessageResponseDto);
             log.info("message.getReceiverId()     :   {}", message.getReceiverId());
             simpMessagingTemplate.convertAndSend("/topic/" + chatRoomId, message);
-            simpMessagingTemplate.convertAndSendToUser(message.getReceiverId().toString(), "/topic/chat-room" , newMessageResponseDto);
+            simpMessagingTemplate.convertAndSend("/topic/" + message.getReceiverId(), newMessageResponseDto);
         }
         catch (ChatException e) {
             log.info("e.getStackTrace()   :   {}", e.getMessage());

--- a/chatting-server/src/main/java/com/lastone/chat/config/StompConfig.java
+++ b/chatting-server/src/main/java/com/lastone/chat/config/StompConfig.java
@@ -14,8 +14,10 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @EnableWebSocketMessageBroker
 @Slf4j
 public class StompConfig implements WebSocketMessageBrokerConfigurer {
-    @Value("${lastOne.front.url}")
-    private String frontEndURL;
+    @Value("${lastOne.front.localURL}")
+    private String localEndURL;
+    @Value("${lastOne.front.prodURL}")
+    private String prodEndURL;
     @Value("${spring.rabbitmq.host}")
     private String host;
     @Value("${lastOne.rabbitmq.username}")
@@ -31,7 +33,7 @@ public class StompConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/chat/stomp")
-                .setAllowedOrigins(frontEndURL, "http://localhost:8082")
+                .setAllowedOrigins(localEndURL, prodEndURL, "http://localhost:8082")
                 .setAllowedOriginPatterns("*")
                 .withSockJS();
     }


### PR DESCRIPTION
## 목록
- 메세지 구독 방식 변경(convertAndSendToUser 에서  convertAndSend로 변경) 
***why? 소켓 연결 시점과 스프링 시큐리티에서 유저정보를 받아오는 시점이 맞지 않는 문제 떄문에***


<br/>

- 배포 서버에서 소켓 연결 가능하도록 allowedOrigin에 관련 설정 추가