### PR TITLE
[Fix]: applicationId Null 값 반환 되는 문제 수정

### DIFF
--- a/core/src/main/java/com/lastone/core/dto/applicaation/ApplicationDto.java
+++ b/core/src/main/java/com/lastone/core/dto/applicaation/ApplicationDto.java
@@ -35,7 +35,7 @@ public class ApplicationDto {
 
     public static ApplicationDto toDto(Application application) {
         return ApplicationDto.builder()
-                .applicantId(application.getId())
+                .applicationId(application.getId())
                 .applicantId(application.getApplicant().getId())
                 .nickname(application.getApplicant().getNickname())
                 .profileUrl(application.getApplicant().getProfileUrl())


### PR DESCRIPTION
## Content

받은 신청 리스트를 조회 할 떄 ApplicationId 부분이 NULL 로 반환되는 문제를 잘못된 dto 관련 로직을 수정하여 해결하였습니다.